### PR TITLE
Julia 0.7-beta2 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
   - osx
 
 julia:
-  - release
+  - 0.7
   - nightly
 
 matrix:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.7-beta2
-LightGraphs 0.7
+LightGraphs 0.13.1
 TikzGraphs 0.7
-MacroTools 0.3
-CommonSubexpressions
+MacroTools 0.4.2
+CommonSubexpressions 0.2

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.5
+julia 0.7-beta2
 LightGraphs 0.7
-TikzGraphs 0.3
+TikzGraphs 0.7
 MacroTools 0.3
 CommonSubexpressions

--- a/src/TreeView.jl
+++ b/src/TreeView.jl
@@ -10,9 +10,11 @@ export LabelledTree, walk_tree, walk_tree!, draw, @tree, @tree_with_call,
 export make_dag, @dag, @dag_cse
 
 
-abstract LabelledDiGraph
+abstract type LabelledDiGraph 
 
-immutable LabelledTree <: LabelledDiGraph
+end
+
+struct LabelledTree <: LabelledDiGraph
     g::DiGraph
     labels::Vector{Any}
 end

--- a/src/TreeView.jl
+++ b/src/TreeView.jl
@@ -10,8 +10,7 @@ export LabelledTree, walk_tree, walk_tree!, draw, @tree, @tree_with_call,
 export make_dag, @dag, @dag_cse
 
 
-abstract type LabelledDiGraph 
-
+abstract type LabelledDiGraph
 end
 
 struct LabelledTree <: LabelledDiGraph
@@ -21,13 +20,8 @@ end
 
 add_numbered_vertex!(g) = (add_vertex!(g); top = nv(g))  # returns the number of the new vertex
 
-
-
 include("tree.jl")
 include("dag.jl")
 include("display.jl")
-
-
-
 
 end # module

--- a/src/dag.jl
+++ b/src/dag.jl
@@ -5,7 +5,7 @@ Structure representing a DAG.
 Maintains a `symbol_map` giving the currently-known symbols and the corresponding
 vertex number in the graph.
 """
-immutable DirectedAcyclicGraph <: LabelledDiGraph
+struct DirectedAcyclicGraph <: LabelledDiGraph
     g::DiGraph
     labels::Vector{Any}
     symbol_map::Dict{Symbol, Int}

--- a/src/dag.jl
+++ b/src/dag.jl
@@ -16,9 +16,8 @@ DirectedAcyclicGraph() = DirectedAcyclicGraph(DiGraph(), Symbol[], Dict())
 """
 Adds a symbol to the DAG if it doesn't already exist.
 Returns the vertex number
-"""
-
 # Make numbers unique:
+"""
 function add_symbol!(dag::DirectedAcyclicGraph, s)  # number
     vertex = add_numbered_vertex!(dag.g)
     push!(dag.labels, s)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -10,7 +10,6 @@ Including them represents the Julia AST more precisely, but adds visual noise.
 
 Returns the number of the top vertex.
 """
-
 function walk_tree!(g, labels, ex, show_call=true)
 
     top_vertex = add_numbered_vertex!(g)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TreeView
-using Base.Test
+using Test
 
 # write your own tests here
 @testset "@tree" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using TreeView
+using LightGraphs
 using Test
 
 # write your own tests here
@@ -6,11 +7,11 @@ using Test
 
     t = @tree 1x
 
-    @test typeof(t) == TreeView.LabelledTree
-    @test typeof(t.g) == LightGraphs.DiGraph
-    @test typeof(t.labels) == Vector{Any}
+    @test isa(t, TreeView.LabelledTree)
+    @test isa(t.g, LightGraphs.DiGraph)
+    @test isa(t.labels, Vector{Any})
 
-    @test t.g.vertices == 1:3
+    @test vertices(t.g) == collect(1:3)
     @test t.labels == Any[:*,1,:x]
 
 


### PR DESCRIPTION
Update TreeView for Julia 0.7-beta2.

Drops support for 0.5 and 0.6, though this is common for 0.7 updates.
Should have no changes in terms of package use and operation.