### PR TITLE
README: percent-encode space in URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ which gives the following output:
 
 ![example_tree](example_tree.png)
 
-See [this notebook](examples/TreeView usage.ipynb) for usage examples.
+See [this notebook](examples/TreeView%20usage.ipynb) for usage examples.
 
 ## Installation prerequisites
 


### PR DESCRIPTION
The link does not work with the raw space in the URL.