### PR TITLE
Change LightGraphs to Graphs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ TikzGraphs = "b4f28e30-c73f-5eaf-a395-8a9db949a742"
 CommonSubexpressions = "0.2, 0.3"
 Graphs = "1.4, 1.5, 1.6"
 MacroTools = "0.4, 0.5"
-TikzGraphs = "1.0, 1.1"
+TikzGraphs = "1.3"
 julia = "^0.7, ^1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -4,13 +4,13 @@ version = "0.4.0"
 
 [deps]
 CommonSubexpressions = "bbf7d656-a473-5ed7-a52c-81e309532950"
-LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 TikzGraphs = "b4f28e30-c73f-5eaf-a395-8a9db949a742"
 
 [compat]
 CommonSubexpressions = "0.2, 0.3"
-LightGraphs = "0.13.1, 0.14, 1.0, 1.1, 1.2, 1.3"
+Graphs = "1.4, 1.5, 1.6"
 MacroTools = "0.4, 0.5"
 TikzGraphs = "1.0, 1.1"
 julia = "^0.7, ^1"

--- a/src/TreeView.jl
+++ b/src/TreeView.jl
@@ -1,6 +1,6 @@
 module TreeView
 
-using LightGraphs, TikzGraphs
+using Graphs, TikzGraphs
 using MacroTools
 using CommonSubexpressions
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using TreeView
-using LightGraphs
+using Graphs
 using Test
 
 # write your own tests here
@@ -8,7 +8,7 @@ using Test
     t = @tree 1x
 
     @test isa(t, TreeView.LabelledTree)
-    @test isa(t.g, LightGraphs.DiGraph)
+    @test isa(t.g, Graphs.DiGraph)
     @test isa(t.labels, Vector{Any})
 
     @test vertices(t.g) == collect(1:3)


### PR DESCRIPTION
This package is currently broken when using [TikzGraphs >= 1.3](https://github.com/JuliaTeX/TikzGraphs.jl/releases/tag/v1.3.0), as they have moved on from the now abandoned LightGraphs package.

I have updated the dependency to Graphs.jl, a new maintained version of LightGraphs.